### PR TITLE
Update homeassistant_ws.py (#549)

### DIFF
--- a/BridgeEmulator/protocols/homeassistant_ws.py
+++ b/BridgeEmulator/protocols/homeassistant_ws.py
@@ -135,7 +135,7 @@ class HomeAssistantClient(WebSocketClient):
                 else:
                     payload["service"] = "turn_off"
             if key == "alert":
-                service_data['alert'] = value
+                service_data['flash'] = "long"
             if key == "transitiontime":
                 service_data['transition'] = value / 10
 


### PR DESCRIPTION
There is no such key alert in turn_on service. https://www.home-assistant.io/integrations/light/#service-lightturn_on

```voluptuous.error.MultipleInvalid: extra keys not allowed @ data['alert']```